### PR TITLE
Prepare package for PyPI publication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,45 @@
+name: Publish to PyPI
+
+# Builds and publishes the package to PyPI whenever a GitHub release is
+# published, or when a version tag (e.g. v0.1.0) is pushed.
+#
+# Requires a repository secret named PYPI_API_TOKEN containing a PyPI API
+# token with upload permissions for this project. Until that secret is
+# configured, this workflow will fail at the "Publish to PyPI" step, but it
+# will not run at all unless a release is published or a matching tag is
+# pushed.
+
+on:
+  release:
+    types: [published]
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install poetry
+        run: curl -sSL https://install.python-poetry.org | python3 - --version=1.4.2
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.9'
+          cache: 'poetry'
+
+      - name: Install dependencies
+        run: poetry -vv install --no-interaction --no-ansi
+
+      - name: Build package
+        run: poetry build
+
+      - name: Publish to PyPI
+        env:
+          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_API_TOKEN }}
+        run: poetry publish --no-interaction

--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # autodocgen
 
+## Installing from PyPI
+
+> Note: this package has not been published to PyPI yet. Once it is
+> published (see [#4](https://github.com/Iodine98/autodocgen/issues/4)),
+> it will become installable via:
+
+```sh
+pip install autodocgen
+```
+
 ## Documentation
 
 1. Install as dependency in Poetry by adding the following line to `pyproject.toml`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,23 @@ version = "0.1.0"
 description = "Automatically generate documentation for Python code using OpenAI models."
 authors = ["Rohan Sobha <rohanraysobha@gmail.com>"]
 readme = "README.md"
+license = "MIT"
+homepage = "https://github.com/Iodine98/autodocgen"
+repository = "https://github.com/Iodine98/autodocgen"
+keywords = ["documentation", "docstring", "openai", "pydoc", "codegen"]
 packages = [{include = "autodocgen", from = "src"}]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Topic :: Documentation",
+    "Topic :: Software Development :: Documentation",
+]
 
 [tool.poetry.dependencies]
 python = "^3.9"


### PR DESCRIPTION
## Summary
- Adds missing PyPI-relevant packaging metadata to `pyproject.toml`: `license = "MIT"` (matching the repo's `LICENSE` file), `classifiers`, `homepage`/`repository` URLs, and `keywords`.
- Adds a new GitHub Actions workflow (`.github/workflows/publish.yml`) that builds the package with Poetry and runs `poetry publish` using a `PYPI_API_TOKEN` secret, triggered on GitHub release publish or on `v*.*.*` tag pushes.
- Adds an "Installing from PyPI" section to `README.md` documenting the future `pip install autodocgen` path, worded honestly as aspirational until the first release.
- Verified locally that `poetry check` passes and `poetry build` successfully produces both an sdist and a wheel with the new metadata.

Closes #4

## Important: publishing itself is NOT done here
This PR only sets up the enabling metadata/automation. It does **not** publish anything to PyPI. Actual publishing still requires the repo owner to:
1. Create a PyPI account/project and generate an API token.
2. Add that token as the `PYPI_API_TOKEN` secret in this repo's GitHub Actions settings.
3. Cut a GitHub release (or push a `vX.Y.Z` tag) to trigger the new workflow.

Until the secret is added and a release/tag is created, the new workflow simply will not run.

## Test plan
- [x] `poetry check` passes
- [x] `poetry build` produces `autodocgen-0.1.0-py3-none-any.whl` and `autodocgen-0.1.0.tar.gz` without errors
- [x] Repo owner adds `PYPI_API_TOKEN` secret and cuts a release to perform the actual first publish