### PR TITLE
Document CLI usage and fix invalid-path error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ## Documentation
 
+### Installation
+
 1. Install as dependency in Poetry by adding the following line to `pyproject.toml`
 
 ```toml
@@ -12,6 +14,46 @@ autodocgen = { git = "https://github.com/Iodine98/autodocgen.git" }
 ```env
 OPENAI_KEY=<your OpenAI key>
 ```
+
+### Usage
+
+`autodocgen` also installs a command-line script of the same name that can be run
+directly from a terminal, without having to call the library from Python:
+
+```shell
+autodocgen <path> [-i] [-s SUFFIX] [--disable_tqdm]
+```
+
+Arguments:
+
+- `path` (required): path to a single Python file or to a directory. When a directory
+  is given, every `.py` file in it (and its subdirectories) is processed, except for
+  `__init__.py` files.
+- `-i`, `--overwrite`, `--inplace`: overwrite the original file(s) in place with the
+  generated docstrings injected. When omitted, a new file is written instead and the
+  original file is left untouched.
+- `-s SUFFIX`, `--suffix SUFFIX`: the suffix appended to the stem of the output file
+  name when *not* overwriting in place, e.g. `my_module.py` becomes `my_module_doc.py`
+  by default. This option is ignored when `-i`/`--overwrite` is used, since the file
+  is overwritten instead of written to a new path.
+- `--disable_tqdm`: disable the progress bar shown while processing a directory.
+
+Examples:
+
+```shell
+# Write documented output to my_module_doc.py, leaving my_module.py untouched
+autodocgen my_module.py
+
+# Overwrite my_module.py in place with the generated docstrings
+autodocgen my_module.py -i
+
+# Process every Python file in ./src, writing "<name>_annotated.py" siblings
+autodocgen ./src -s _annotated
+
+# Process a directory in place without showing a progress bar
+autodocgen ./src -i --disable_tqdm
+```
+
 2. Call the ASTAnalyzer and ensure that the `model_name` is correct. 
 
 The default values are below

--- a/src/autodocgen/cli.py
+++ b/src/autodocgen/cli.py
@@ -1,6 +1,7 @@
 import argparse
 import logging
 import os
+import sys
 import time
 from pathlib import Path
 from tqdm import tqdm
@@ -105,7 +106,6 @@ def main():
     )
     parser.add_argument("--disable_tqdm", help="Disable the progress bar", action="store_true")
     args = parser.parse_args()
-    print(args)
     path: Path = Path(args.path)
     if path.is_file() and path.suffix == ".py":
         process_python_file(file_path=path, overwrite_file=args.overwrite, stem_suffix=args.suffix)
@@ -116,8 +116,12 @@ def main():
             stem_suffix=args.suffix,
             disable_tqdm=args.disable_tqdm,
         )
+    elif not path.exists():
+        print(f"Error: path '{path}' does not exist", file=sys.stderr)
+        sys.exit(1)
     else:
-        print("Invalid path or file type")
+        print(f"Error: '{path}' is not a Python file or a directory", file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/tests/autodocgen/test_cli.py
+++ b/tests/autodocgen/test_cli.py
@@ -1,0 +1,31 @@
+import sys
+
+import pytest
+
+from src.autodocgen import cli
+
+
+def test_main_exits_nonzero_for_missing_path(monkeypatch, tmp_path, capsys):
+    missing_path = tmp_path / "does_not_exist.py"
+    monkeypatch.setattr(sys, "argv", ["autodocgen", str(missing_path)])
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main()
+    assert exc_info.value.code == 1
+    assert "does not exist" in capsys.readouterr().err
+
+
+def test_main_exits_nonzero_for_non_python_file(monkeypatch, tmp_path, capsys):
+    non_python_file = tmp_path / "not_python.txt"
+    non_python_file.write_text("hello")
+    monkeypatch.setattr(sys, "argv", ["autodocgen", str(non_python_file)])
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main()
+    assert exc_info.value.code == 1
+    assert "not a Python file" in capsys.readouterr().err
+
+
+def test_main_requires_path_argument(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["autodocgen"])
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main()
+    assert exc_info.value.code == 2


### PR DESCRIPTION
## Summary

Investigated GitHub issue #3 ("Turn application into cmdline app"). The
`autodocgen` console-script entry point (`src/autodocgen/cli.py` +
`[tool.poetry.scripts]` in `pyproject.toml`) already existed and, after
installing the package into a fresh virtualenv, `autodocgen --help` and
argument parsing work correctly end-to-end. What was actually missing/broken:

- **README had zero documentation of the CLI.** The only documented usage was
  calling `ASTAnalyzer` directly from Python; there was nothing about the
  `autodocgen <path> [-i] [-s SUFFIX] [--disable_tqdm]` command at all.
- **Leftover debug `print(args)`** in `main()`.
- **Invalid/missing paths silently exited 0** with a vague "Invalid path or
  file type" message printed to stdout — not useful for scripting/CI, since a
  failed invocation looked like a success.

## Changes

- `README.md`: added a "Usage" section documenting the `autodocgen` CLI,
  its flags, and example invocations.
- `src/autodocgen/cli.py`: removed the stray `print(args)`; `main()` now
  prints a specific error to stderr and exits with status 1 when the given
  path doesn't exist, or isn't a `.py` file or directory.
- `tests/autodocgen/test_cli.py` (new): covers the two new error paths and
  argparse's required-`path`-argument behavior.

Closes #3

## Test plan

- [x] Bootstrapped a clean virtualenv, installed the package (`pip install -e .`
      with the `pyproject.toml` deps), and confirmed `autodocgen --help` works
      and the console script is wired correctly for the `src` layout.
- [x] Manually verified `autodocgen <missing-path>` and
      `autodocgen <non-py-file>` now print a clear error to stderr and exit 1.
- [x] `pytest tests/` passes (6 tests: 3 existing `ASTAnalyzer` tests + 3 new
      CLI tests).
- [x] Did not call the OpenAI API in any test.