### PR TITLE
Fix deploy workflow: upgrade actions/checkout and actions/setup-python

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,13 +11,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install poetry
         run: curl -sSL https://install.python-poetry.org | python3 - --version=1.4.2
 
       - name: Set up Python 3.9
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9'
           cache: 'poetry'


### PR DESCRIPTION
## Summary
- The `Deploy` workflow (added in #15) failed on the first run after merging to `main`, at the "Set up Python 3.9" step, with `##[error]Cache service responded with 400`.
- Root cause: `actions/checkout@v3` and `actions/setup-python@v3` are pinned to old major versions that bundle an outdated `@actions/cache` client incompatible with GitHub's current Actions cache service backend.
- Fix: bump to `actions/checkout@v4` and `actions/setup-python@v5`, which use a cache client compatible with the current service.

Failed run: https://github.com/Iodine98/autodocgen/actions/runs/28699692978

## Test plan
- [ ] Merge to `main` and confirm the `Deploy` workflow's "Set up Python 3.9" step succeeds (no cache 400 error)
- [ ] Confirm `poetry install`, `poetry build`, and `poetry publish` steps run (publish still requires `PYPI_API_TOKEN`/`POETRY_PYPI_TOKEN_PYPI` secret to be set in repo settings)